### PR TITLE
Set initial player count and skip to five

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -329,10 +329,7 @@ class App {
         // Setup create game validation
         this.setupCreateGameValidation();
         
-        // Initialize with 5 players if starting at 0
-        if (this.getCurrentPlayerCount() === 0) {
-            this.updatePlayerCount(5);
-        }
+        // Start at 0 players; first increment will jump to 5
     }
 
     setupCreateGameValidation() {

--- a/pages/play.html
+++ b/pages/play.html
@@ -227,19 +227,23 @@
              * Binds click, input, and change events to their respective handlers
              */
             setupEventListeners() {
-                // Player count controls - increment button
+                // Player count controls - increment button (0 -> 5 on first add)
                 document.getElementById('increase-btn').addEventListener('click', () => {
                         const currentCount = this.getCurrentPlayerCount();
-                    if (currentCount < 10) {  // Maximum 10 players allowed
+                    if (currentCount === 0) {
+                        this.updatePlayerCount(5);
+                    } else if (currentCount < 10) {  // Maximum 10 players allowed
                         this.updatePlayerCount(currentCount + 1);
                     }
                 });
 
-                // Player count controls - decrement button
+                // Player count controls - decrement button (5 -> 0 on remove)
                 document.getElementById('decrease-btn').addEventListener('click', () => {
                         const currentCount = this.getCurrentPlayerCount();
-                    if (currentCount > 0) {  // Minimum 0 players
+                    if (currentCount > 5) {  // Above minimum playable count
                         this.updatePlayerCount(currentCount - 1);
+                    } else if (currentCount === 5) {
+                        this.updatePlayerCount(0);
                     }
                 });
 

--- a/pages/play_clean.html
+++ b/pages/play_clean.html
@@ -732,15 +732,19 @@
                 // Player count controls
                 document.getElementById('increase-btn').addEventListener('click', () => {
                     const currentCount = this.getCurrentPlayerCount();
-                    if (currentCount < 10) {
+                    if (currentCount === 0) {
+                        this.updatePlayerCount(5);
+                    } else if (currentCount < 10) {
                         this.updatePlayerCount(currentCount + 1);
                     }
                 });
 
                 document.getElementById('decrease-btn').addEventListener('click', () => {
                     const currentCount = this.getCurrentPlayerCount();
-                    if (currentCount > 0) {
+                    if (currentCount > 5) {
                         this.updatePlayerCount(currentCount - 1);
+                    } else if (currentCount === 5) {
+                        this.updatePlayerCount(0);
                     }
                 });
 


### PR DESCRIPTION
Update game creation page player count to start at 0 and skip to 5 on first add, and from 5 to 0 on first remove, as 2-4 players is not a valid state.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd62b78a-96e1-4d4c-b68a-9e989280a706">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd62b78a-96e1-4d4c-b68a-9e989280a706">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

